### PR TITLE
fix: use correct api in java code

### DIFF
--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
@@ -16,14 +16,14 @@ public class AndroidShortcutsPlugin extends Plugin {
     @PluginMethod
     public void isDynamicSupported(PluginCall call) {
         JSObject ret = new JSObject();
-        ret.put("value", implementation.isDynamicSupported(this.getContext()));
+        ret.put("result", implementation.isDynamicSupported(this.getContext()));
         call.resolve(ret);
     }
 
     @PluginMethod
     public void isPinnedSupported(PluginCall call) {
         JSObject ret = new JSObject();
-        ret.put("value", implementation.isPinnedSupported(this.getContext()));
+        ret.put("result", implementation.isPinnedSupported(this.getContext()));
         call.resolve(ret);
     }
 


### PR DESCRIPTION
Currently the typescript API says that the `isDynamicSupported` and `isPinnedSupported` return something like this:

```ts
{ result: boolean }
```

But the Java code currently returns this:

```ts
{ value: boolean }
```
