### PR TITLE
feat: adds possibility to use ressource-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Checks if pinned shortcuts are supported on the device
 ### addDynamic(...)
 
 ```typescript
-addDynamic(options: { items: { id: string; shortLabel: string; longLabel: string; iconBitmap: string; data: string; }[]; }) => any
+addDynamic(options: { items: ShortcutItem[]; }) => any
 ```
 
 Created dynamic shortcuts
@@ -136,14 +136,14 @@ Created dynamic shortcuts
 ### addPinned(...)
 
 ```typescript
-addPinned(options: { id: string; shortLabel: string; longLabel: string; iconBitmap: string; data: string; }) => any
+addPinned(options: ShortcutItem) => any
 ```
 
 Created a pinned shortcut
 
-| Param         | Type                                                                                                  | Description                              |
-| ------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| **`options`** | <code>{ id: string; shortLabel: string; longLabel: string; iconBitmap: string; data: string; }</code> | An option object for the pinned shortcut |
+| Param         | Type                                                                                                                                  | Description                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **`options`** | <code>{ id: string; shortLabel: string; longLabel: string; icon?: { type: AvailableIconTypes; name: string; }; data: string; }</code> | An option object for the pinned shortcut |
 
 **Returns:** <code>any</code>
 
@@ -158,10 +158,10 @@ addListener(eventName: 'shortcut', listenerFunc: MessageListener) => Promise<Plu
 
 Add a listener to a shortcut tap event
 
-| Param              | Type                                    |
-| ------------------ | --------------------------------------- |
-| **`eventName`**    | <code>"shortcut"</code>                 |
-| **`listenerFunc`** | <code>(response: any) =&gt; void</code> |
+| Param              | Type                                                  |
+| ------------------ | ----------------------------------------------------- |
+| **`eventName`**    | <code>"shortcut"</code>                               |
+| **`listenerFunc`** | <code>(response: { data: string; }) =&gt; void</code> |
 
 **Returns:** <code>any</code>
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,20 @@ AndroidShortcuts.isDynamicSupported().then(({ result }) => {
                     id: "myfirstid",
                     shortLabel: "My first short label",
                     longLabel: "My first long label",
-                    iconBitmap: "BASE64DATA",
+                    icon: {
+                        type: "Bitmap",
+                        name: "<base64-string>"
+                    },
                     data: "I am a simple string",
                 },
                 {
                     id: "mysecondid",
                     shortLabel: "My first short label",
                     longLabel: "My first long label",
-                    iconBitmap: "BASE64DATA",
+                    icon: {
+                        type: "Resource",
+                        name: "<vector-asset-name>"
+                    },
                     data: JSON.stringify({
                         myProperty: "Pass a stringified JSON object",
                     }),
@@ -69,7 +75,10 @@ AndroidShortcuts.isPinnedSupported().then(({ result }) => {
             id: "mypinnedid",
             shortLabel: "My pinned short label",
             longLabel: "My pinned long label",
-            iconBitmap: "BASE64DATA",
+            icon: {
+                type: "Bitmap",
+                name: "<base64-string>"
+            },
             data: "I am a simple string",
         });
     }

--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcuts.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcuts.java
@@ -56,7 +56,7 @@ public class AndroidShortcuts {
             ShortcutIcon shortcutIcon = null;
             try {
                 JSONObject iconObject = item.getJSONObject("icon");
-                shortcutIcon = new ShortcutIcon(iconObject.getString("type"), iconObject.getString("name"));
+                shortcutIcon = new ShortcutIcon(ShortcutIconEnum.valueOf(iconObject.getString("type")), iconObject.getString("name"));
             } catch (JSONException e) {
                 System.out.println("'icon' Object is not parsable");
             }
@@ -100,9 +100,9 @@ public class AndroidShortcuts {
         }
 
         try {
-            if (shortcutIcon.getType().equals("Bitmap")) {
+            if (shortcutIcon.getType().equals(ShortcutIconEnum.Bitmap)) {
                 return Icon.createWithBitmap(decodeBase64Bitmap(shortcutIcon.getName()));
-            } else if (shortcutIcon.getType().equals("Ressource")) {
+            } else if (shortcutIcon.getType().equals(ShortcutIconEnum.Resource)) {
                 Resources activityRes = bridge.getContext().getResources();
                 String activityPackage = bridge.getActivity().getPackageName();
                 return Icon.createWithResource(bridge.getContext(), activityRes.getIdentifier(shortcutIcon.getName(), "drawable", activityPackage));

--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
@@ -1,7 +1,6 @@
 package nepheus.capacitor.androidshortcuts;
 
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
 import android.os.Build;
 
@@ -60,7 +59,7 @@ public class AndroidShortcutsPlugin extends Plugin {
         ShortcutIcon shortcutIcon = null;
         try {
             JSONObject iconObject = call.getObject("icon");
-            shortcutIcon = new ShortcutIcon(iconObject.getString("type"), iconObject.getString("name"));
+            shortcutIcon = new ShortcutIcon(ShortcutIconEnum.valueOf(iconObject.getString("type")), iconObject.getString("name"));
         } catch (JSONException e) {
             System.out.println("'icon' Object is not parsable");
         }

--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
@@ -1,12 +1,21 @@
 package nepheus.capacitor.androidshortcuts;
 
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @CapacitorPlugin(name = "AndroidShortcuts")
 public class AndroidShortcutsPlugin extends Plugin {
@@ -41,15 +50,24 @@ public class AndroidShortcutsPlugin extends Plugin {
     }
 
     @PluginMethod
+    @RequiresApi(api = Build.VERSION_CODES.M)
     public void addPinned(PluginCall call) {
         String id = call.getString("id");
         String shortLabel = call.getString("shortLabel");
         String longLabel = call.getString("longLabel");
-        String iconBitmap = call.getString("iconBitmap");
         String data = call.getString("data");
 
+        ShortcutIcon shortcutIcon = null;
         try {
-            implementation.addPinned(this.getBridge(), id, shortLabel, longLabel, iconBitmap, data);
+            JSONObject iconObject = call.getObject("icon");
+            shortcutIcon = new ShortcutIcon(iconObject.getString("type"), iconObject.getString("name"));
+        } catch (JSONException e) {
+            System.out.println("'icon' Object is not parsable");
+        }
+
+        try {
+            Icon icon = implementation.generateIcon(bridge, shortcutIcon);
+            implementation.addPinned(this.getBridge(), id, shortLabel, longLabel, icon, data);
         } catch (Exception e) {
             call.reject(e.getMessage());
         }

--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/ShortcutIcon.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/ShortcutIcon.java
@@ -1,20 +1,21 @@
 package nepheus.capacitor.androidshortcuts;
 
 public class ShortcutIcon {
-    private final String type;
+    private final ShortcutIconEnum type;
 
     private final String name;
 
-    public ShortcutIcon(String type, String name) {
+    public ShortcutIcon(ShortcutIconEnum type, String name) {
         this.type = type;
         this.name = name;
     }
 
     /**
-     * Returns the type of the icon. Can be: "Bitmap" or "Ressource"
-     * @return "Bitmap" or "Ressource"
+     * Returns the type of the icon as an enum.
+     * 
+     * @return type of the icon
      */
-    public String getType() {
+    public ShortcutIconEnum getType() {
         return this.type;
     }
 

--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/ShortcutIcon.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/ShortcutIcon.java
@@ -1,0 +1,24 @@
+package nepheus.capacitor.androidshortcuts;
+
+public class ShortcutIcon {
+    private final String type;
+
+    private final String name;
+
+    public ShortcutIcon(String type, String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    /**
+     * Returns the type of the icon. Can be: "Bitmap" or "Ressource"
+     * @return "Bitmap" or "Ressource"
+     */
+    public String getType() {
+        return this.type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/ShortcutIconEnum.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/ShortcutIconEnum.java
@@ -1,0 +1,5 @@
+package nepheus.capacitor.androidshortcuts;
+
+public enum ShortcutIconEnum {
+    Bitmap, Resource;
+}

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,6 +1,6 @@
-import { PluginListenerHandle } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 
-export type AvailableIconTypes = "Bitmap" | "Ressource";
+export type AvailableIconTypes = "Bitmap" | "Resource";
 
 export type ShortcutItem = {
   /**
@@ -22,7 +22,7 @@ export type ShortcutItem = {
   longLabel: string;
   /**
    * Defines the icon of the shortcut.
-   * You can set the icon as a BASE64-Bitmap or as a Ressource name
+   * You can set the icon as a BASE64-Bitmap or as a Resource name
    */
   icon?: {
     /**
@@ -30,7 +30,7 @@ export type ShortcutItem = {
      */
     type: AvailableIconTypes;
     /**
-     * Name of te Ressource or data of the encoded Bitmap
+     * Name of te Resource or data of the encoded Bitmap
      */
     name: string;
   }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,45 @@
 import { PluginListenerHandle } from '@capacitor/core';
 
+export type AvailableIconTypes = "Bitmap" | "Ressource";
+
+export type ShortcutItem = {
+  /**
+   * ID of the shortcut
+   */
+  id: string;
+  /**
+   * Sets the short title of a shortcut.
+   * This is a mandatory field when publishing a new shortcut with ShortcutManager.addDynamicShortcuts(List) or ShortcutManager.setDynamicShortcuts(List).
+   * This field is intended to be a concise description of a shortcut.
+   * The recommended maximum length is 10 characters.
+   */
+  shortLabel: string;
+  /**
+   * Sets the text of a shortcut.
+   * This field is intended to be more descriptive than the shortcut title. The launcher shows this instead of the short title when it has enough space.
+   * The recommend maximum length is 25 characters.
+   */
+  longLabel: string;
+  /**
+   * Defines the icon of the shortcut.
+   * You can set the icon as a BASE64-Bitmap or as a Ressource name
+   */
+  icon?: {
+    /**
+     * Type of the icon
+     */
+    type: AvailableIconTypes;
+    /**
+     * Name of te Ressource or data of the encoded Bitmap
+     */
+    name: string;
+  }
+  /**
+   * Data you will receive when the shortcut is opened
+   */
+  data: string;
+};
+
 export interface AndroidShortcutsPlugin {
   /**
    * Checks if dynamic shortcuts are supported on the device
@@ -14,25 +54,13 @@ export interface AndroidShortcutsPlugin {
    * @param options An items array with the options of each shortcut
    */
   addDynamic(options: {
-    items: {
-      id: string;
-      shortLabel: string;
-      longLabel: string;
-      iconBitmap: string;
-      data: string;
-    }[];
+    items: ShortcutItem[];
   }): Promise<void>;
   /**
    * Created a pinned shortcut
    * @param options An option object for the pinned shortcut
    */
-  addPinned(options: {
-    id: string;
-    shortLabel: string;
-    longLabel: string;
-    iconBitmap: string;
-    data: string;
-  }): Promise<void>;
+  addPinned(options: ShortcutItem): Promise<void>;
   /**
    * Add a listener to a shortcut tap event
    * @param eventName
@@ -44,4 +72,4 @@ export interface AndroidShortcutsPlugin {
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
 }
 
-export type MessageListener = (response: any) => void;
+export type MessageListener = (response: { data: string }) => void;

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 import { WebPlugin } from '@capacitor/core';
 
-import { MessageListener, AndroidShortcutsPlugin } from './definitions';
+import { ShortcutItem, MessageListener, AndroidShortcutsPlugin } from './definitions';
 
 export class AndroidShortcutsWeb
   extends WebPlugin
@@ -12,29 +12,17 @@ export class AndroidShortcutsWeb
     throw new Error('Method not implemented.');
   }
   addDynamic(options: {
-    items: {
-      id: string;
-      shortLabel: string;
-      longLabel: string;
-      iconBitmap: string;
-      data: string;
-    }[];
+    items: ShortcutItem[];
   }): Promise<void> {
     console.error("Method 'add' not implemented.", JSON.stringify(options));
     return Promise.reject("Method 'add' not implemented.") as any;
   }
-  addPinned(options: {
-    id: string;
-    shortLabel: string;
-    longLabel: string;
-    iconBitmap: string;
-    data: string;
-  }): Promise<void> {
+  addPinned(options: ShortcutItem): Promise<void> {
     console.error("Method 'add' not implemented.", options);
     return Promise.reject("Method 'add' not implemented.") as any;
   }
   addListener(eventName: 'shortcut', listenerFunc: MessageListener) {
-    listenerFunc(null);
+    listenerFunc({ data: "" });
     return Promise.reject(
       `Listener for '${eventName}' not implemented.`,
     ) as any;


### PR DESCRIPTION
Hi there!
I wanted to add some Icons and actually wasn't able to transform my SVG-Icon to an encoded bitmap.
That's why I opened the API a bit to add an Icon by a resource name (e.g. ic_launcher_background).

I'm looking forward to your review! 😄 
