### PR TITLE
fix: flip equals on handleOnNewIntent to fix crashes

### DIFF
--- a/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
+++ b/android/src/main/java/nepheus/capacitor/androidshortcuts/AndroidShortcutsPlugin.java
@@ -82,7 +82,7 @@ public class AndroidShortcutsPlugin extends Plugin {
     protected void handleOnNewIntent(Intent intent) {
         super.handleOnNewIntent(intent);
 
-        if (intent.getAction().equals(Intent.EXTRA_SHORTCUT_INTENT)) {
+        if (Intent.EXTRA_SHORTCUT_INTENT.equals(intent.getAction())) {
             JSObject ret = new JSObject();
             ret.put("data", intent.getStringExtra("data"));
             notifyListeners("shortcut", ret, true);


### PR DESCRIPTION
After releasing an app version with this plugin I get some crashes of users:
![image](https://user-images.githubusercontent.com/48101693/135390656-6fcdfd20-89ef-4cb9-b27c-ddf5824fe597.png)

I actually can't say what the users are doing that the Intent is null there, but with flipping the equals comparison the problem shouldn't appear anymore