### PR TITLE
Add removeAllListeners method to definitions

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -70,6 +70,11 @@ export interface AndroidShortcutsPlugin {
     eventName: 'shortcut',
     listenerFunc: MessageListener,
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
+
+  /**
+   * Removes all listeners.
+   */
+  removeAllListeners(): Promise<void>;
 }
 
 export type MessageListener = (response: { data: string }) => void;


### PR DESCRIPTION
I suppose this method should be defined whenever Capacitor plugin defines `addListener` method.

I'm not completely sure how, but it's available in this plugin (tried with `console.log(AndroidShortcuts.removeAllListeners))`), just it's not visible.

References:
- [@capacitor/screen-orientation](https://github.com/ionic-team/capacitor-plugins/tree/main/screen-orientation) source
- capacitor Docs > Designing the Plugin API > [Defining the ScreenOrientation API​](https://capacitorjs.com/docs/plugins/tutorial/designing-the-plugin-api#defining-the-screenorientation-api)